### PR TITLE
WEBDEV-4861: Retry request if it fails

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -35,6 +35,11 @@
       div.innerHTML = response;
     }
 
+        // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+        async function loadScriptFailure() {
+          await lazyLoaderService.loadScript({ src: 'blahblah.js' });
+        }
+
     render(
       html`
         <h1>Lazy Loader Service</h1>
@@ -45,10 +50,15 @@
           window.someLibrary.foo();
         </pre>
         <center>
+          <h2>Success</h2>
           <button @click=${loadScript}>Lazy Load Script</button>
           <p>(inspect the page head tag before and after pushing this)</p>
           <div>Response:</div>
           <div id="lazy-response"></div>
+
+          <h2>Failure</h2>
+          <button @click=${loadScriptFailure}>Lazy Load Failure</button>
+          <p>Inspect the page head tag and network panel before and after pushing this. You should see a three script tags and three network failures.</p>
         </center>
       `,
       document.querySelector('#demo')

--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,6 @@
-export { LazyLoaderService } from './src/lazy-loader-service';
+export {
+  LazyLoaderService,
+  LazyLoaderServiceOptions,
+} from './src/lazy-loader-service';
 export { LazyLoaderServiceInterface } from './src/lazy-loader-service-interface';
 export { BundleType } from './src/bundle-type';

--- a/index.ts
+++ b/index.ts
@@ -2,5 +2,8 @@ export {
   LazyLoaderService,
   LazyLoaderServiceOptions,
 } from './src/lazy-loader-service';
-export { LazyLoaderServiceInterface } from './src/lazy-loader-service-interface';
+export {
+  LazyLoaderServiceInterface,
+  LazyLoaderServiceEvents,
+} from './src/lazy-loader-service-interface';
 export { BundleType } from './src/bundle-type';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@internetarchive/lazy-loader-service",
-  "version": "0.2.0-alpha.4",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/lazy-loader-service",
-      "version": "0.2.0-alpha.4",
+      "version": "0.2.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "nanoevents": "^6.0.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@internetarchive/lazy-loader-service",
-  "version": "0.1.0",
+  "version": "0.2.0-alpha.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/lazy-loader-service",
-      "version": "0.1.0",
+      "version": "0.2.0-alpha.2",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "nanoevents": "^6.0.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@internetarchive/lazy-loader-service",
-  "version": "0.2.0-alpha.3",
+  "version": "0.2.0-alpha.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/lazy-loader-service",
-      "version": "0.2.0-alpha.3",
+      "version": "0.2.0-alpha.4",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "nanoevents": "^6.0.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "@internetarchive/lazy-loader-service",
       "version": "0.1.0",
       "license": "AGPL-3.0-only",
+      "dependencies": {
+        "nanoevents": "^6.0.2"
+      },
       "devDependencies": {
         "@open-wc/eslint-config": "^2.0.0",
         "@open-wc/testing": "^2.0.0",
@@ -9080,6 +9083,14 @@
       "resolved": "https://registry.npmjs.org/nanocolors/-/nanocolors-0.2.13.tgz",
       "integrity": "sha512-0n3mSAQLPpGLV9ORXT5+C/D4mwew7Ebws69Hx4E2sgz2ZA5+32Q80B9tL8PbL7XHnRDiAxH/pnrUJ9a4fkTNTA==",
       "dev": true
+    },
+    "node_modules/nanoevents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/nanoevents/-/nanoevents-6.0.2.tgz",
+      "integrity": "sha512-FRS2otuFcPPYDPYViNWQ42+1iZqbXydinkRHTHFxrF4a1CpBfmydR9zkI44WSXAXCyPrkcGtPk5CnpW6Y3lFKQ==",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
     },
     "node_modules/nanomatch": {
       "version": "1.2.13",
@@ -20026,6 +20037,11 @@
       "resolved": "https://registry.npmjs.org/nanocolors/-/nanocolors-0.2.13.tgz",
       "integrity": "sha512-0n3mSAQLPpGLV9ORXT5+C/D4mwew7Ebws69Hx4E2sgz2ZA5+32Q80B9tL8PbL7XHnRDiAxH/pnrUJ9a4fkTNTA==",
       "dev": true
+    },
+    "nanoevents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/nanoevents/-/nanoevents-6.0.2.tgz",
+      "integrity": "sha512-FRS2otuFcPPYDPYViNWQ42+1iZqbXydinkRHTHFxrF4a1CpBfmydR9zkI44WSXAXCyPrkcGtPk5CnpW6Y3lFKQ=="
     },
     "nanomatch": {
       "version": "1.2.13",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@internetarchive/lazy-loader-service",
-  "version": "0.2.0-alpha.2",
+  "version": "0.2.0-alpha.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/lazy-loader-service",
-      "version": "0.2.0-alpha.2",
+      "version": "0.2.0-alpha.3",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "nanoevents": "^6.0.2"

--- a/package.json
+++ b/package.json
@@ -60,5 +60,8 @@
       "prettier --write",
       "git add"
     ]
+  },
+  "dependencies": {
+    "nanoevents": "^6.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "format:prettier": "prettier \"**/*.js\" \"**/*.ts\" --write --ignore-path .gitignore",
     "lint": "npm run lint:eslint && npm run lint:prettier",
     "format": "npm run format:eslint && npm run format:prettier",
-    "test": "npm run lint && tsc && karma start --coverage",
+    "test": "npm run lint && tsc && concurrently \"node ./test/test-server.js\" \"karma start --coverage\"",
     "test:watch": "concurrently --kill-others --names tsc,karma \"npm run tsc:watch\" \"karma start --auto-watch=true --single-run=false\""
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/lazy-loader-service",
-  "version": "0.1.0",
+  "version": "0.2.0-alpha.2",
   "description": "A small library to lazy load javascript with a Promise",
   "license": "AGPL-3.0-only",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "format:prettier": "prettier \"**/*.js\" \"**/*.ts\" --write --ignore-path .gitignore",
     "lint": "npm run lint:eslint && npm run lint:prettier",
     "format": "npm run format:eslint && npm run format:prettier",
-    "test": "npm run lint && tsc && concurrently \"node ./test/test-server.js\" \"karma start --coverage\"",
+    "test": "npm run lint && tsc && concurrently \"node ./test/retry-server.js\" \"karma start --coverage\"",
     "test:watch": "concurrently --kill-others --names tsc,karma \"npm run tsc:watch\" \"karma start --auto-watch=true --single-run=false\""
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/lazy-loader-service",
-  "version": "0.2.0-alpha.4",
+  "version": "0.2.0",
   "description": "A small library to lazy load javascript with a Promise",
   "license": "AGPL-3.0-only",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/lazy-loader-service",
-  "version": "0.2.0-alpha.2",
+  "version": "0.2.0-alpha.3",
   "description": "A small library to lazy load javascript with a Promise",
   "license": "AGPL-3.0-only",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/lazy-loader-service",
-  "version": "0.2.0-alpha.3",
+  "version": "0.2.0-alpha.4",
   "description": "A small library to lazy load javascript with a Promise",
   "license": "AGPL-3.0-only",
   "main": "dist/index.js",

--- a/src/bundle-type.ts
+++ b/src/bundle-type.ts
@@ -1,4 +1,1 @@
-export enum BundleType {
-  Module = 'module',
-  NoModule = 'nomodule',
-}
+export type BundleType = 'module' | 'nomodule';

--- a/src/lazy-loader-service-interface.ts
+++ b/src/lazy-loader-service-interface.ts
@@ -13,10 +13,7 @@ export interface LazyLoaderServiceInterface {
    *
    * @param bundle
    */
-  loadBundle(bundle: {
-    module?: string;
-    nomodule?: string;
-  }): Promise<Event | undefined>;
+  loadBundle(bundle: { module?: string; nomodule?: string }): Promise<void>;
 
   /**
    * Load a script with a Promise
@@ -35,5 +32,5 @@ export interface LazyLoaderServiceInterface {
     bundleType?: BundleType;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     attributes?: Record<string, string>;
-  }): Promise<Event | undefined>;
+  }): Promise<void>;
 }

--- a/src/lazy-loader-service-interface.ts
+++ b/src/lazy-loader-service-interface.ts
@@ -2,7 +2,7 @@ import { BundleType } from './bundle-type';
 import { Unsubscribe } from 'nanoevents';
 
 export interface LazyLoaderServiceEvents {
-  scriptLoadRetried: (src: string, retryCount: number) => void;
+  scriptLoadRetried: (src: string, retryNumber: number) => void;
   scriptLoadFailed: (src: string, error: string | Event) => void;
 }
 

--- a/src/lazy-loader-service-interface.ts
+++ b/src/lazy-loader-service-interface.ts
@@ -8,13 +8,13 @@ export interface LazyLoaderServiceEvents {
 
 export interface LazyLoaderServiceInterface {
   /**
-   * Bind to receive credit card flow handler events
+   * Bind to receive notifications about retry and failure events
    *
    * @template E
    * @param {E} event
-   * @param {CreditCardFlowHandlerEvents[E]} callback
+   * @param {LazyLoaderServiceEvents[E]} callback
    * @returns {Unsubscribe}
-   * @memberof CreditCardFlowHandlerInterface
+   * @memberof LazyLoaderServiceInterface
    */
   on<E extends keyof LazyLoaderServiceEvents>(
     event: E,

--- a/src/lazy-loader-service-interface.ts
+++ b/src/lazy-loader-service-interface.ts
@@ -34,6 +34,6 @@ export interface LazyLoaderServiceInterface {
     src: string;
     bundleType?: BundleType;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    attributes?: { key: string; value: any }[];
+    attributes?: Record<string, string>;
   }): Promise<Event | undefined>;
 }

--- a/src/lazy-loader-service-interface.ts
+++ b/src/lazy-loader-service-interface.ts
@@ -1,6 +1,26 @@
 import { BundleType } from './bundle-type';
+import { Unsubscribe } from 'nanoevents';
+
+export interface LazyLoaderServiceEvents {
+  scriptLoadRetried: (src: string, retryCount: number) => void;
+  scriptLoadFailed: (src: string, error: string | Event) => void;
+}
 
 export interface LazyLoaderServiceInterface {
+  /**
+   * Bind to receive credit card flow handler events
+   *
+   * @template E
+   * @param {E} event
+   * @param {CreditCardFlowHandlerEvents[E]} callback
+   * @returns {Unsubscribe}
+   * @memberof CreditCardFlowHandlerInterface
+   */
+  on<E extends keyof LazyLoaderServiceEvents>(
+    event: E,
+    callback: LazyLoaderServiceEvents[E]
+  ): Unsubscribe;
+
   /**
    * Load a javascript bundle (module and nomodule pair)
    *

--- a/src/lazy-loader-service.ts
+++ b/src/lazy-loader-service.ts
@@ -113,9 +113,8 @@ export class LazyLoaderService implements LazyLoaderServiceInterface {
         }
       };
 
-      if (script.parentNode === null) {
-        this.container.appendChild(script);
-      } else if (script.getAttribute('dynamicImportLoaded')) {
+      // script has already been loaded, just resolve
+      if (script.getAttribute('dynamicImportLoaded')) {
         resolve();
       }
     });

--- a/src/lazy-loader-service.ts
+++ b/src/lazy-loader-service.ts
@@ -95,11 +95,11 @@ export class LazyLoaderService implements LazyLoaderServiceInterface {
     src: string;
     bundleType?: BundleType;
     attributes?: Record<string, string>;
-    retryCount?: number;
+    retryNumber?: number;
     scriptBeingRetried?: HTMLScriptElement;
   }): Promise<void> {
-    const retryCount = options.retryCount ?? 0;
-    const scriptSelector = `script[src='${options.src}'][async][retryCount='${retryCount}']`;
+    const retryNumber = options.retryNumber ?? 0;
+    const scriptSelector = `script[src='${options.src}'][async][retryCount='${retryNumber}']`;
     let script = this.container.querySelector(
       scriptSelector
     ) as HTMLScriptElement;
@@ -136,14 +136,14 @@ export class LazyLoaderService implements LazyLoaderServiceInterface {
 
       script.onerror = async (error): Promise<void> => {
         const hasBeenRetried = script.getAttribute('hasBeenRetried');
-        if (retryCount < this.retryCount && !hasBeenRetried) {
+        if (retryNumber < this.retryCount && !hasBeenRetried) {
           script.setAttribute('hasBeenRetried', 'true');
           await promisedSleep(this.retryInterval * 1000);
-          const newRetryCount = retryCount + 1;
-          this.emitter.emit('scriptLoadRetried', options.src, newRetryCount);
+          const newRetryNumber = retryNumber + 1;
+          this.emitter.emit('scriptLoadRetried', options.src, newRetryNumber);
           this.doLoad({
             ...options,
-            retryCount: newRetryCount,
+            retryNumber: newRetryNumber,
             scriptBeingRetried: script,
           });
         } else {

--- a/src/lazy-loader-service.ts
+++ b/src/lazy-loader-service.ts
@@ -147,7 +147,12 @@ export class LazyLoaderService implements LazyLoaderServiceInterface {
             scriptBeingRetried: script,
           });
         } else {
-          this.emitter.emit('scriptLoadFailed', options.src, error);
+          // only emit a failure event from the last attempt, which has not been retried.
+          // otherwise you get failure events from each script tag, when we're really
+          // only interested that the entire chain failed
+          if (!hasBeenRetried) {
+            this.emitter.emit('scriptLoadFailed', options.src, error);
+          }
           originalOnError?.(error);
           reject(error);
         }

--- a/src/promised-sleep.ts
+++ b/src/promised-sleep.ts
@@ -1,0 +1,15 @@
+/**
+ * Asynchronously pause execution for a given number of milliseconds.
+ *
+ * Used for waiting for some asynchronous updates.
+ *
+ * Usage:
+ * await promisedSleep(100)
+ *
+ * @export
+ * @param {number} ms
+ * @returns {Promise<void>}
+ */
+export function promisedSleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/test/lazy-loader-service.test.ts
+++ b/test/lazy-loader-service.test.ts
@@ -183,6 +183,46 @@ describe('Lazy Loader Service', () => {
       expect(retryFailed).to.be.true;
     });
 
+    it('Emits the expected number of retry events', async () => {
+      const container = (await fixture(html` <div></div> `)) as HTMLElement;
+      const lazyLoader = new LazyLoaderService({
+        container,
+        retryCount: 4,
+        retryInterval: 0.01,
+      });
+
+      let retryEvents = 0;
+      lazyLoader.on('scriptLoadRetried', () => {
+        retryEvents += 1;
+      });
+
+      try {
+        await lazyLoader.loadScript({ src: '/base/test/blahblah.js' });
+      } catch {}
+
+      expect(retryEvents).to.equal(4);
+    });
+
+    it('Only emits a single failure event if there are multiple retry attempts', async () => {
+      const container = (await fixture(html` <div></div> `)) as HTMLElement;
+      const lazyLoader = new LazyLoaderService({
+        container,
+        retryCount: 4,
+        retryInterval: 0.01,
+      });
+
+      let failureEvents = 0;
+      lazyLoader.on('scriptLoadFailed', () => {
+        failureEvents += 1;
+      });
+
+      try {
+        await lazyLoader.loadScript({ src: '/base/test/blahblah.js' });
+      } catch {}
+
+      expect(failureEvents).to.equal(1);
+    });
+
     it('Retries the specified number of times', async () => {
       const container = (await fixture(html` <div></div> `)) as HTMLElement;
       const lazyLoader = new LazyLoaderService({

--- a/test/lazy-loader-service.test.ts
+++ b/test/lazy-loader-service.test.ts
@@ -15,7 +15,7 @@ describe('Lazy Loader Service', () => {
   describe('loadBundle', () => {
     it('Can load bundles', async () => {
       const container = (await fixture(html` <div></div> `)) as HTMLElement;
-      const lazyLoader = new LazyLoaderService(container);
+      const lazyLoader = new LazyLoaderService({ container });
       await lazyLoader.loadBundle({
         module: testServiceUrl,
         nomodule: testServiceUrl,
@@ -29,7 +29,7 @@ describe('Lazy Loader Service', () => {
   describe('loadScript', () => {
     it('Creates proper script tags in container', async () => {
       const container = (await fixture(html` <div></div> `)) as HTMLElement;
-      const lazyLoader = new LazyLoaderService(container);
+      const lazyLoader = new LazyLoaderService({ container });
 
       await lazyLoader.loadScript({ src: testServiceUrl });
 
@@ -39,7 +39,7 @@ describe('Lazy Loader Service', () => {
 
     it('Only loads scripts once if called multiple times', async () => {
       const container = (await fixture(html` <div></div> `)) as HTMLElement;
-      const lazyLoader = new LazyLoaderService(container);
+      const lazyLoader = new LazyLoaderService({ container });
 
       await lazyLoader.loadScript({ src: testServiceUrl });
       await lazyLoader.loadScript({ src: testServiceUrl });
@@ -51,7 +51,7 @@ describe('Lazy Loader Service', () => {
 
     it('Loaded script is usable', async () => {
       const container = (await fixture(html` <div></div> `)) as HTMLElement;
-      const lazyLoader = new LazyLoaderService(container);
+      const lazyLoader = new LazyLoaderService({ container });
       await lazyLoader.loadScript({ src: testServiceUrl });
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -61,7 +61,7 @@ describe('Lazy Loader Service', () => {
 
     it('Can pass in attributes', async () => {
       const container = (await fixture(html` <div></div> `)) as HTMLElement;
-      const lazyLoader = new LazyLoaderService(container);
+      const lazyLoader = new LazyLoaderService({ container });
       await lazyLoader.loadScript({
         src: testServiceUrl,
         attributes: { foo: 'bar' },
@@ -74,7 +74,7 @@ describe('Lazy Loader Service', () => {
 
     it('Can load modules', async () => {
       const container = (await fixture(html` <div></div> `)) as HTMLElement;
-      const lazyLoader = new LazyLoaderService(container);
+      const lazyLoader = new LazyLoaderService({ container });
       await lazyLoader.loadScript({
         src: testServiceUrl,
         bundleType: BundleType.Module,
@@ -89,7 +89,7 @@ describe('Lazy Loader Service', () => {
     // made, that they all get their completion blocks called
     it('Calls multiple onloads if requested', async () => {
       const container = (await fixture(html` <div></div> `)) as HTMLElement;
-      const lazyLoader = new LazyLoaderService(container);
+      const lazyLoader = new LazyLoaderService({ container });
 
       const count = 25;
 
@@ -117,7 +117,7 @@ describe('Lazy Loader Service', () => {
     // made, that they all get their completion blocks called
     it('Calls multiple onerrors if requested', async () => {
       const container = (await fixture(html` <div></div> `)) as HTMLElement;
-      const lazyLoader = new LazyLoaderService(container);
+      const lazyLoader = new LazyLoaderService({ container });
 
       const count = 25;
 

--- a/test/lazy-loader-service.test.ts
+++ b/test/lazy-loader-service.test.ts
@@ -1,6 +1,5 @@
 import { expect, fixture, html } from '@open-wc/testing';
 import { LazyLoaderService } from '../src/lazy-loader-service';
-import { BundleType } from '../src/bundle-type';
 
 const testServiceUrl = '/base/dist/test/test-service.js';
 
@@ -77,7 +76,7 @@ describe('Lazy Loader Service', () => {
       const lazyLoader = new LazyLoaderService({ container });
       await lazyLoader.loadScript({
         src: testServiceUrl,
-        bundleType: BundleType.Module,
+        bundleType: 'module',
       });
 
       const script = container.querySelector('script');

--- a/test/lazy-loader-service.test.ts
+++ b/test/lazy-loader-service.test.ts
@@ -117,7 +117,10 @@ describe('Lazy Loader Service', () => {
     // made, that they all get their completion blocks called
     it('Calls multiple onerrors if requested', async () => {
       const container = (await fixture(html` <div></div> `)) as HTMLElement;
-      const lazyLoader = new LazyLoaderService({ container });
+      const lazyLoader = new LazyLoaderService({
+        container,
+        retryInterval: 0.1,
+      });
 
       const count = 25;
 

--- a/test/lazy-loader-service.test.ts
+++ b/test/lazy-loader-service.test.ts
@@ -37,20 +37,6 @@ describe('Lazy Loader Service', () => {
       expect(scripts.length).to.equal(1);
     });
 
-    it('Removes the script tag if the load fails', async () => {
-      const container = (await fixture(html` <div></div> `)) as HTMLElement;
-      const lazyLoader = new LazyLoaderService(container);
-
-      try {
-        await lazyLoader.loadScript({ src: './blahblahnotfound.js' });
-      } catch {
-        // expected failure
-      }
-
-      const scripts = container.querySelectorAll('script');
-      expect(scripts.length).to.equal(0);
-    });
-
     it('Only loads scripts once if called multiple times', async () => {
       const container = (await fixture(html` <div></div> `)) as HTMLElement;
       const lazyLoader = new LazyLoaderService(container);
@@ -78,7 +64,7 @@ describe('Lazy Loader Service', () => {
       const lazyLoader = new LazyLoaderService(container);
       await lazyLoader.loadScript({
         src: testServiceUrl,
-        attributes: [{ key: 'foo', value: 'bar' }],
+        attributes: { foo: 'bar' },
       });
 
       const script = container.querySelector('script');

--- a/test/lazy-loader-service.test.ts
+++ b/test/lazy-loader-service.test.ts
@@ -176,6 +176,7 @@ describe('Lazy Loader Service', () => {
       });
 
       // verify the final load actually loaded the service
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const result = (window as any).otherService.getResponse();
       expect(result).to.equal('someotherresponse');
     });

--- a/test/retry-server.js
+++ b/test/retry-server.js
@@ -1,6 +1,5 @@
 const http = require('http');
 const fs = require('fs');
-const { exit } = require('process');
 
 /**
  * This file is to test the lazy loader retry functionality.
@@ -9,7 +8,7 @@ const { exit } = require('process');
  * the second request will return a 200, then shut down.
  */
 
-const lockFile = './file.txt';
+const lockFile = './retry_lockfile.txt';
 let server;
 
 function deleteLockfile() {

--- a/test/test-server.js
+++ b/test/test-server.js
@@ -1,0 +1,52 @@
+const http = require('http');
+const fs = require('fs');
+const { exit } = require('process');
+
+/**
+ * This file is to test the lazy loader retry functionality.
+ *
+ * The first request to the server will always return a 404,
+ * the second request will return a 200, then shut down.
+ */
+
+const lockFile = './file.txt';
+let server;
+
+function deleteLockfile() {
+  if (fs.existsSync(lockFile)) {
+    fs.unlinkSync(lockFile);
+  }
+}
+
+function shutdown() {
+  deleteLockfile();
+  server.close();
+  process.exit();
+}
+
+process
+  .on('SIGTERM', shutdown)
+  .on('SIGINT', shutdown)
+  .on('uncaughtException', shutdown);
+
+const requestListener = function (req, res) {
+  try {
+    if (fs.existsSync(lockFile)) {
+      res.writeHead(200);
+      res.end(
+        'window.otherService = { getResponse() { return "someotherresponse"; }}'
+      );
+      shutdown();
+    } else {
+      fs.writeFileSync(lockFile, 'locked');
+      res.writeHead(404);
+      res.end('Not Found');
+    }
+  } catch (err) {
+    console.error(err);
+  }
+};
+
+deleteLockfile();
+server = http.createServer(requestListener);
+server.listen(5432);


### PR DESCRIPTION
This adds support for retrying script loads if they fail. By default, it will retry twice and wait 1 second in between retries.

The service will now also emit an event when it retries or fails so consumers can respond by logging the events if they wish.